### PR TITLE
Fix running DeepLC from multiprocessing environment

### DIFF
--- a/deeplc/deeplc.py
+++ b/deeplc/deeplc.py
@@ -32,6 +32,7 @@ import copy
 import gc
 import logging
 import multiprocessing
+import multiprocessing.dummy
 import os
 import pickle
 import sys
@@ -278,7 +279,11 @@ class DeepLC():
             feature matrix
         """
         df_instances_split = np.array_split(df_instances, self.n_jobs)
-        pool = multiprocessing.Pool(self.n_jobs)
+        if multiprocessing.current_process().daemon:
+            logging.warn("DeepLC is running in a daemon process. Disabling multiprocessing as daemonic processes can't have children.")
+            pool = multiprocessing.dummy.Pool(1)
+        else:
+            pool = multiprocessing.Pool(self.n_jobs)
         if self.n_jobs == 1:
             df = self.do_f_extraction_pd(df_instances)
         else:


### PR DESCRIPTION
`multiprocessing` uses daemonic processes. POSIX doesn't allow daemonic processes to have children, i.e. you can't nest multiprocessing pools. This tests if the current process is a daemonic process, and if so, uses a dummy pool using threads instead. Due to the GIL, using multiple threads won't make this faster, unless DeepLC would be IO-bound.