### PR TITLE
Drop restriction on python 3.8

### DIFF
--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v1

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,5 @@ setup(
         'numpy>=1.17,<2',
         'pandas>=0.25,<2',
     ],
-    python_requires='>=3.6,<3.8',
+    python_requires='>=3.6',
 )


### PR DESCRIPTION
Since tensorflow 2.2.0 was released, DeepLC should be compatible with
Python 3.8 now.

Note that I didn't give this a lot of testing, so there might still be another issue, although judging by the changelog, I don't think so.