### PR TITLE
Support Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'numpy>=1.17,<2',
         'pandas>=0.25,<2',
         'matplotlib>=3,<4',
-        'h5py>=2.10.0,<3'
+        'h5py>=2.10.0,<4'
     ],
     python_requires='>=3.6',
 )


### PR DESCRIPTION
By relaxing the dependency of h5py, we can use Tensorflow 2.5, adding support for Python 3.9. h5py 3.0 does introduce [breaking changes](https://docs.h5py.org/en/latest/whatsnew/3.0.html), but at first glance, this doesn't seem to be relevant for DeepLC.