### PR TITLE
Fix Streamlit container tags yaml formatting

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,6 +73,6 @@ jobs:
       with:
         context: streamlit
         push: true
-        tags:
-          - ghcr.io/compomics/deeplc-streamlit:${{ steps.latest_release.outputs.release }}
-          - ghcr.io/compomics/deeplc-streamlit:latest
+        tags: |
+          ghcr.io/compomics/deeplc-streamlit:${{ steps.latest_release.outputs.release }}
+          ghcr.io/compomics/deeplc-streamlit:latest


### PR DESCRIPTION
Github Actions inputs do not support YAML lists. The workaround is to use new line-delimited or comma-delimited strings (https://github.com/docker/build-push-action#inputs).

Should fix failed run https://github.com/compomics/DeepLC/actions/runs/921042655