### PR TITLE
use logger instead of logging

### DIFF
--- a/deeplc/__main__.py
+++ b/deeplc/__main__.py
@@ -25,6 +25,8 @@ from deeplc._exceptions import DeepLCError
 
 __version__ = pkg_resources.require("deeplc")[0].version
 
+logger = logging.getLogger(__name__)
+
 
 def parse_arguments():
     """Read arguments from the command line."""
@@ -193,7 +195,7 @@ def main():
             use_library=argu.use_library
             )
     except DeepLCError as e:
-        logging.exception(e)
+        logger.exception(e)
         sys.exit(1)
 
 
@@ -243,7 +245,7 @@ def run(file_pred="",
     None
     """
 
-    logging.info("Using DeepLC version %s", __version__)
+    logger.info("Using DeepLC version %s", __version__)
 
     if len(file_cal) == 0 and file_model != None:
         fm_dict = {}
@@ -296,24 +298,24 @@ def run(file_pred="",
 
     # Calibrate the original model based on the new retention times
     if len(file_cal) > 1:
-        logging.info("Selecting best model and calibrating predictions...")
+        logger.info("Selecting best model and calibrating predictions...")
         dlc.calibrate_preds(seq_df=df_cal)
 
     # Make predictions; calibrated or uncalibrated
-    logging.info("Making predictions using model: %s", dlc.model)
+    logger.info("Making predictions using model: %s", dlc.model)
     if len(file_cal) > 1:
         preds = dlc.make_preds(seq_df=df_pred)
     else:
         preds = dlc.make_preds(seq_df=df_pred, calibrate=False)
 
     df_pred["predicted_tr"] = preds
-    logging.debug("Writing predictions to file: %s", file_pred_out)
+    logger.debug("Writing predictions to file: %s", file_pred_out)
     df_pred.to_csv(file_pred_out)
 
     if plot_predictions:
         if len(file_cal) > 1 and "tr" in df_pred.columns:
             file_pred_figure = os.path.splitext(file_pred_out)[0] + '.png'
-            logging.debug("Saving scatterplot of predictions to file: %s", file_pred_figure)
+            logger.debug("Saving scatterplot of predictions to file: %s", file_pred_figure)
             plt.figure(figsize=(11.5, 9))
             plt.scatter(df_pred["tr"], df_pred["predicted_tr"], s=3)
             plt.title("DeepLC predictions")
@@ -321,10 +323,10 @@ def run(file_pred="",
             plt.ylabel("Predicted retention times")
             plt.savefig(file_pred_figure, dpi=300)
         else:
-            logging.warning('No observed retention time in input data. Cannot \
+            logger.warning('No observed retention time in input data. Cannot \
 plot predictions')
 
-    logging.info("DeepLC finished!")
+    logger.info("DeepLC finished!")
 
 
 if __name__ == "__main__":

--- a/deeplc/deeplc_fit_model.py
+++ b/deeplc/deeplc_fit_model.py
@@ -41,6 +41,9 @@ from numpy import logspace
 import numpy as np
 
 
+logger = logging.getLogger(__name__)
+
+
 def fit_lasso(X_train,
               y_train,
               X_test,
@@ -266,7 +269,7 @@ def fit_xgb(X_train, y_train, X_test, y_test, config_file="config.ini"):
     model = xgb.XGBRegressor(**random_search.best_params_)
 
     if verbose > 0:
-        logging.debug("Predicting tR with CV now...")
+        logger.debug("Predicting tR with CV now...")
     train_cross_preds = cross_val_predict(model, X_train, y_train, cv=cv)
 
     random_search.feats = X_train.columns
@@ -274,9 +277,9 @@ def fit_xgb(X_train, y_train, X_test, y_test, config_file="config.ini"):
     test_preds = xgb_model.predict(X_test)
 
     if verbose > 0:
-        logging.debug("=====")
-        logging.debug(random_search.best_params_)
-        logging.debug(random_search.best_score_)
-        logging.debug("=====")
+        logger.debug("=====")
+        logger.debug(random_search.best_params_)
+        logger.debug(random_search.best_score_)
+        logger.debug("=====")
 
     return train_preds, train_cross_preds, test_preds, random_search

--- a/deeplc/feat_extractor.py
+++ b/deeplc/feat_extractor.py
@@ -27,6 +27,9 @@ import numpy as np
 import pandas as pd
 
 
+logger = logging.getLogger(__name__)
+
+
 class FeatExtractor():
     """
     Place holder, fill later
@@ -367,7 +370,7 @@ class FeatExtractor():
                                 feature_seq_split in enumerate(feature_seqs_split)]))
 
         if self.verbose:
-            logging.debug(
+            logger.debug(
                 "Time to calculate features: %s seconds" %
                 (time.time() - t0))
 
@@ -587,7 +590,7 @@ class FeatExtractor():
                     mod_dict[index_name]["%s%s%s" %
                                          (fm, relative_loc, add_str)] += n
         if self.verbose:
-            logging.debug(
+            logger.debug(
                 "Time to calculate mod features: %s seconds" %
                 (time.time() - t0))
         df_ret = pd.DataFrame(mod_dict, dtype=int).T
@@ -670,7 +673,7 @@ class FeatExtractor():
                     mod_dict[index_name]["%s%s%s" %
                                          (f, relative_loc, add_str)] += chem_descr[f]
         if self.verbose:
-            logging.debug(
+            logger.debug(
                 "Time to calculate mod features: %s seconds" %
                 (time.time() - t0))
         return pd.DataFrame(mod_dict).T
@@ -731,7 +734,7 @@ class FeatExtractor():
             try:
                 split_mod = mod.split("|")
             except BaseException:
-                logging.debug(
+                logger.debug(
                     "Not able to split the following mod properly: %s" %
                     (mod))
                 split_mod = []
@@ -753,11 +756,11 @@ class FeatExtractor():
                     try:
                         mod_comp[split_mod[i - 1] - 1][atom] += atom_change
                     except KeyError:
-                        logging.debug(
+                        logger.debug(
                             "Skipping the following atom in modification: %s,%s,%s,%s,%s,%s" %
                             (split_mod[i], atom, atom_change, ident, mod, seq))
                     except IndexError:
-                        logging.debug(
+                        logger.debug(
                             "Index does not exist for: %s,%s,%s,%s,%s" %
                             (atom, atom_change, ident, mod, seq))
 
@@ -765,11 +768,11 @@ class FeatExtractor():
                     try:
                         mod_comp[split_mod[i - 1] - 1][atom] -= atom_change
                     except KeyError:
-                        logging.debug(
+                        logger.debug(
                             "Skipping the following atom in modification: %s,%s,%s,%s,%s,%s" %
                             (split_mod[i], atom, atom_change, ident, mod, seq))
                     except IndexError:
-                        logging.debug(
+                        logger.debug(
                             "Index does not exist for: %s,%s,%s,%s,%s" %
                             (atom, atom_change, ident, mod, seq))
 
@@ -1020,7 +1023,7 @@ class FeatExtractor():
                     mod_add = self.lib_add[mods[i]]
                     mod_sub = self.lib_subtract[mods[i]]
                 except KeyError:
-                    logging.debug(
+                    logger.debug(
                         "Skipping the following modification due to it not being present in the library: %s" %
                         (mods[i]))
                     continue
@@ -1055,11 +1058,11 @@ class FeatExtractor():
                                        len(seq), dict_index_pos[atom]] += val
 
                     except KeyError:
-                        logging.debug(
+                        logger.debug(
                             "Skipping the following atom in modification: %s" %
                             (atom))
                     except IndexError:
-                        logging.debug(
+                        logger.debug(
                             "Index does not exist for: ",
                             atom,
                             atom_change,
@@ -1077,11 +1080,11 @@ class FeatExtractor():
                                        len(seq), dict_index_pos[atom]] -= val
 
                     except KeyError:
-                        logging.debug(
+                        logger.debug(
                             "Skipping the following atom in modification: %s" %
                             (atom))
                     except IndexError:
-                        logging.debug(
+                        logger.debug(
                             "Index does not exist for: ",
                             atom,
                             atom_change,
@@ -1149,27 +1152,27 @@ class FeatExtractor():
 
         if self.standard_feat:
             if self.verbose:
-                logging.debug("Extracting standard features")
+                logger.debug("Extracting standard features")
             X = self.get_feats(seqs, identifiers, split_size=self.split_size)
         if self.add_comp_feat:
             if self.verbose:
-                logging.debug("Extracting compositional features")
+                logger.debug("Extracting compositional features")
             X_comp = self.get_comp_change_mods(seqs, mods, identifiers)
         if self.add_sum_feat:
             if self.verbose:
-                logging.debug(
+                logger.debug(
                     "Extracting compositional sum features for modifications")
             X_feats_sum = self.get_feats_mods(
                 seqs, mods, identifiers, split_size=1, add_str="_sum")
         if self.ptm_add_feat:
             if self.verbose:
-                logging.debug(
+                logger.debug(
                     "Extracting compositional add features for modifications")
             X_feats_add = self.get_feats_mods(
                 seqs, mods, identifiers, split_size=self.split_size, add_str="_add")
         if self.ptm_subtract_feat:
             if self.verbose:
-                logging.debug(
+                logger.debug(
                     "Extracting compositional subtract features for modifications")
             X_feats_neg = self.get_feats_mods(
                 seqs,
@@ -1180,13 +1183,13 @@ class FeatExtractor():
                 subtract_mods=True)
         if self.chem_descr_feat:
             if self.verbose:
-                logging.debug(
+                logger.debug(
                     "Extracting chemical descriptors features for modifications")
             X_feats_chem_descr = self.get_feats_chem_descr(
                 seqs, mods, identifiers, split_size=3, add_str="_chem_desc")
         if self.cnn_feats:
             if self.verbose:
-                logging.debug("Extracting CNN features")
+                logger.debug("Extracting CNN features")
             X_cnn, X_sum, X_cnn_pos, X_cnn_count, X_hc = self.encode_atoms(
                 seqs, mods, identifiers, charges=charges)
             X_cnn = pd.concat(
@@ -1229,7 +1232,7 @@ class FeatExtractor():
                 X = X_feats_chem_descr
 
         if self.verbose:
-            logging.debug(
+            logger.debug(
                 "Time to calculate all features: %s seconds" %
                 (time.time() - t0))
         return X


### PR DESCRIPTION
Using our own logger instead of the root logger enables downstream users to easily set the DeepLC logging level separately from the rest of the application.