### PR TITLE
Use importlib to get installed version

### DIFF
--- a/deeplc/__init__.py
+++ b/deeplc/__init__.py
@@ -1,7 +1,13 @@
-import pkg_resources
+import sys
+
+
+if sys.version_info >= (3,8):
+    from importlib.metadata import version
+    __version__ = version('deeplc')
+else:
+    import pkg_resources
+    __version__ = pkg_resources.require("deeplc")[0].version
+
 
 from deeplc.deeplc import DeepLC
 from deeplc.feat_extractor import FeatExtractor
-
-
-__version__ = pkg_resources.require("deeplc")[0].version


### PR DESCRIPTION
If Python 3.8 or higher, use importlib.metadata instead of deprecated `pkg_resources.require`. Required for cx_freeze compatibility.