### PR TITLE
add scikit-learn dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest scikit-learn
+        pip install flake8 pytest
         pip install --editable .
     - name: Lint with flake8
       run: |

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'matplotlib>=3,<4',
         'h5py>=2.10.0,<4',
         'pygam>=0.8.0,<1',
-        'scikit-learn>=1.0.0,<2',
+        'scikit-learn>=0.24.0,<2',
     ],
     python_requires='>=3.6',
 )

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,8 @@ setup(
         'pandas>=0.25,<2',
         'matplotlib>=3,<4',
         'h5py>=2.10.0,<4',
-        'pygam>=0.8.0,<1'
+        'pygam>=0.8.0,<1',
+        'scikit-learn>=1.0.0,<2',
     ],
     python_requires='>=3.6',
 )


### PR DESCRIPTION
675f5ab676e33ed4f7eee9824a830417f647664e introduces the use of sklearn, but doesn't add it to the dependencies. As the new `deeplc.trainl3` is always imported, 0.2.0 currently doesn't work unless you also install scikit-learn. Alternatively, we could make the import optional, in which case we could make scikit-learn an optional dependency.