### PR TITLE
Fix memory leak due to repeatedly calling model.predict(...)

### DIFF
--- a/deeplc/deeplc.py
+++ b/deeplc/deeplc.py
@@ -587,6 +587,8 @@ class DeepLC:
             except:
                 ret_preds = self.calibration_core(ret_preds,self.calibrate_dict,self.calibrate_min,self.calibrate_max)
         
+        clear_session()
+        gc.collect()
         return ret_preds
 
     def make_preds(self,

--- a/deeplc/deeplc.py
+++ b/deeplc/deeplc.py
@@ -57,6 +57,9 @@ if IS_CLI_GUI or IS_FROZEN:
     warnings.filterwarnings("ignore", category=FutureWarning)
     warnings.filterwarnings("ignore", category=UserWarning)
 
+# Supress warnings (or at least try...)
+logging.getLogger('tensorflow').setLevel(logging.ERROR)
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 
 import numpy as np
 import pandas as pd
@@ -115,9 +118,6 @@ def warn(*args, **kwargs):
     pass
 import warnings
 warnings.warn = warn
-
-# Supress warnings (or at least try...)
-os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3' 
 
 warnings.filterwarnings('ignore', category=DeprecationWarning)
 warnings.filterwarnings('ignore', category=FutureWarning)


### PR DESCRIPTION
See this issue for details: https://github.com/keras-team/keras/issues/13118

The changes I've made at least fix that memory leak for me when predictions are split into the batches. Also, I did not noticed any performance drops due to the fix.

Also, the second commit fixes the TF warnings supression.

Regards,
Mark